### PR TITLE
Exploradores con permiso de conducción

### DIFF
--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -102,7 +102,7 @@
 	                    SKILL_WEAPONS     = SKILL_EXPERT)
 
 	access = list(
-		access_explorer, access_maint_tunnels, access_eva, access_emergency_storage,
+		access_explorer, access_maint_tunnels, access_eva, access_emergency_storage, access_expedition_shuttle_helm,
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
 		access_petrov, access_petrov_maint, access_research, access_radio_exp
 	)


### PR DESCRIPTION
Le da acceso a los exploradores para conducir la Gaunt sin presencia necesaria de un Shuttle pilot puesto que a la pop actual no da para mucha posibilidad de tener uno, (En cuyo caso de que aparezca uno, los exploradores lo dejarían conducir)