### PR TITLE
Accesos del Inf Tech

### DIFF
--- a/modular_boh/code/modules/jobs/jobs.dm
+++ b/modular_boh/code/modules/jobs/jobs.dm
@@ -100,7 +100,7 @@ var/const/INF               =(1<<11)
 		/datum/mil_rank/marine_corps/e4,
 		/datum/mil_rank/marine_corps/e5
 		)
-	access = list(access_maint_tunnels, access_petrov, access_petrov_security,
+	access = list(access_maint_tunnels, access_solgov_crew, access_petrov, access_petrov_security,
 			            access_expedition_shuttle, access_expedition_shuttle_helm, access_guppy, access_hangar, access_guppy_helm, access_infantry,
 			            access_inftech, access_aquila, access_eva)
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega al Tecnico de infanteria el acceso "access_solgov_crew" para que pueda usar tambien los controles del airlock de las naves como el resto de infanteria.

## ¿Por qué es bueno para el juego?
No tener acceso a esa consolita para entrar y salir de la nave esta feo.

## Changelog
:cl:
**add:** Acceso "access_solgov_crew" Al Inf Tech
/:cl: