### PR TITLE
Estructuras con mas enemigos

### DIFF
--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -113,10 +113,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_bridge)
-"ao" = (
-/turf/space,
-/turf/space,
-/area/space)
 "ap" = (
 /turf/simulated/floor/tiled,
 /area/casino/casino_bridge)
@@ -150,6 +146,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/pirate/ranged,
 /turf/simulated/floor/tiled,
 /area/casino/casino_bridge)
 "av" = (
@@ -487,6 +484,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/plating,
 /area/casino/casino_maintenance)
 "bw" = (
@@ -975,6 +973,7 @@
 /area/casino/casino_security)
 "cA" = (
 /obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/pirate,
 /turf/simulated/floor/tiled,
 /area/casino/casino_security)
 "cB" = (
@@ -2620,6 +2619,7 @@
 /area/casino/casino_mainfloor)
 "gY" = (
 /obj/random/cash,
+/mob/living/simple_animal/hostile/pirate/ranged,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "gZ" = (
@@ -3164,6 +3164,7 @@
 	icon_state = "4-8";
 	pixel_x = 0
 	},
+/mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
 "ix" = (
@@ -3861,6 +3862,7 @@
 /area/casino/casino_mainfloor)
 "kg" = (
 /obj/item/trash/cigbutt/professionals,
+/mob/living/simple_animal/hostile/pirate,
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
 "kh" = (
@@ -4845,6 +4847,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/plating,
 /area/casino/casino_bow)
 "mJ" = (
@@ -5124,6 +5127,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_mainfloor)
+"oR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/mob/living/simple_animal/hostile/pirate,
+/turf/simulated/floor/tiled,
+/area/casino/casino_hangar)
 "pb" = (
 /obj/item/ammo_casing/pistol/magnum/used,
 /turf/simulated/floor/tiled,
@@ -5246,6 +5259,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_crew_cantina)
+"ud" = (
+/obj/item/ammo_casing/rifle/used,
+/obj/item/ammo_casing/rifle/used,
+/mob/living/simple_animal/hostile/pirate,
+/turf/simulated/floor/tiled,
+/area/casino/casino_bridge)
+"uI" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/mob/living/simple_animal/hostile/pirate,
+/turf/simulated/floor/tiled,
+/area/casino/casino_crew_bunk)
 "vb" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/item/ammo_casing/rifle/used,
@@ -5332,6 +5356,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_crew_cantina)
+"yS" = (
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/plating,
+/area/casino/casino_bow)
 "zb" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
@@ -5390,6 +5418,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_crew_cantina)
+"BA" = (
+/obj/effect/floor_decal/industrial/warning,
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/plating,
+/area/casino/casino_crew_atmos)
 "Cb" = (
 /obj/item/ammo_casing/rifle/used,
 /obj/item/ammo_casing/rifle/used,
@@ -5537,10 +5570,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
-"Ib" = (
-/turf/simulated/wall/r_wall,
-/turf/simulated/wall/r_wall,
-/area/casino/casino_bow)
+"Hk" = (
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/plating,
+/area/casino/casino_maintenance)
 "Ic" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/light{
@@ -5656,6 +5689,10 @@
 	},
 /turf/simulated/floor/carpet,
 /area/casino/casino_mainfloor)
+"MH" = (
+/mob/living/simple_animal/hostile/pirate,
+/turf/simulated/floor/carpet,
+/area/casino/casino_mainfloor)
 "Nb" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -5704,6 +5741,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_crew_atmos)
+"Ov" = (
+/obj/effect/decal/cleanable/blood/drip,
+/mob/living/simple_animal/hostile/pirate/ranged,
+/turf/simulated/floor/wood,
+/area/casino/casino_private_vip)
 "Pb" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5754,6 +5796,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_bow)
+"Qd" = (
+/mob/living/simple_animal/hostile/pirate,
+/turf/simulated/floor/tiled,
+/area/casino/casino_kitchen)
 "Rb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -5976,6 +6022,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/casino/casino_security)
+"Yt" = (
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/plating,
+/area/casino/casino_storage)
 "Zb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9691,7 +9741,7 @@ aa
 aa
 aa
 aa
-ao
+aa
 am
 at
 at
@@ -9901,7 +9951,7 @@ ap
 ap
 aE
 aJ
-qb
+ud
 aW
 am
 bk
@@ -9945,7 +9995,7 @@ ml
 mH
 mN
 kC
-Ib
+kC
 aa
 aa
 aa
@@ -10019,7 +10069,7 @@ cp
 eL
 bW
 bW
-bW
+Hk
 fP
 gh
 gA
@@ -10142,7 +10192,7 @@ ka
 jN
 jN
 jN
-le
+BA
 lA
 kC
 mm
@@ -10405,7 +10455,7 @@ aa
 aa
 aa
 aa
-ao
+aa
 am
 at
 at
@@ -10831,7 +10881,7 @@ df
 dx
 dP
 ek
-ek
+Yt
 eQ
 bZ
 bz
@@ -10928,7 +10978,7 @@ aB
 bC
 ca
 cv
-cN
+uI
 dg
 dx
 dQ
@@ -10960,7 +11010,7 @@ kI
 kR
 lh
 lH
-lG
+Ov
 lI
 kC
 mR
@@ -11047,7 +11097,7 @@ vc
 fQ
 ht
 hw
-hw
+Qd
 hV
 hw
 hw
@@ -12188,7 +12238,7 @@ mg
 mz
 kC
 mR
-mH
+yS
 mZ
 aa
 aa
@@ -12362,7 +12412,7 @@ dG
 Ub
 dp
 eG
-eX
+oR
 bq
 bq
 bq
@@ -12473,7 +12523,7 @@ ge
 ge
 ge
 hj
-ge
+MH
 hN
 ie
 is
@@ -12998,7 +13048,7 @@ ge
 ic
 ge
 ge
-ge
+MH
 hB
 ge
 mE

--- a/maps/away/icarus/icarus-1.dmm
+++ b/maps/away/icarus/icarus-1.dmm
@@ -42,6 +42,7 @@
 /area/icarus/vessel)
 "an" = (
 /obj/structure/bed/chair/comfy/captain,
+/mob/living/simple_animal/hostile/meat/abomination,
 /turf/simulated/floor/wood,
 /area/icarus/vessel)
 "ao" = (
@@ -402,6 +403,7 @@
 "bE" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meat/strippedhuman,
 /turf/simulated/floor/tiled/white,
 /area/icarus/vessel)
 "bF" = (
@@ -1940,6 +1942,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash,
+/mob/living/simple_animal/hostile/meat/horrorminer,
 /turf/unsimulated/beach/sand,
 /area/icarus/vessel)
 "gk" = (
@@ -2661,6 +2664,11 @@
 /obj/effect/shuttle_landmark/nav_icarus/nav1,
 /turf/simulated/floor/exoplanet/grass,
 /area/icarus/open)
+"jx" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meat/horrorminer,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
 "kb" = (
 /obj/effect/shuttle_landmark/nav_icarus/nav2,
 /turf/simulated/floor/exoplanet/grass,
@@ -2705,6 +2713,55 @@
 /obj/random/soap,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
+/area/icarus/vessel)
+"qF" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/meat/abomination,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"qW" = (
+/mob/living/simple_animal/hostile/meat/horrorsmall,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"tQ" = (
+/mob/living/simple_animal/hostile/meat/horror,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"Dw" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meat/horror,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"DC" = (
+/mob/living/simple_animal/hostile/meat/horrorminer,
+/turf/simulated/floor/plating,
+/area/icarus/vessel)
+"Gr" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meat/horrorsmall,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"RY" = (
+/mob/living/simple_animal/hostile/meat/horrorsmall,
+/turf/simulated/floor/plating,
+/area/icarus/vessel)
+"Us" = (
+/mob/living/simple_animal/hostile/meat/humansecurity,
+/turf/simulated/floor/wood,
+/area/icarus/vessel)
+"Yo" = (
+/mob/living/simple_animal/hostile/meat/humansecurity,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"Yw" = (
+/obj/structure/sign/warning/caution{
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/mob/living/simple_animal/hostile/meat/horror,
+/turf/simulated/floor/plating,
 /area/icarus/vessel)
 
 (1,1,1) = {"
@@ -20548,7 +20605,7 @@ dg
 cV
 aX
 cV
-dg
+qF
 cV
 aX
 dP
@@ -20824,7 +20881,7 @@ cf
 aP
 as
 ah
-ah
+DC
 ah
 ah
 ah
@@ -21759,7 +21816,7 @@ cZ
 aP
 cZ
 aP
-aP
+tQ
 dB
 aP
 dJ
@@ -22553,7 +22610,7 @@ aD
 aF
 as
 aP
-aP
+Yo
 aP
 bl
 aX
@@ -23153,7 +23210,7 @@ af
 ah
 aj
 ak
-aj
+Us
 ay
 aj
 aG
@@ -23168,13 +23225,13 @@ aX
 aX
 as
 aP
-aP
+tQ
 aP
 aP
 aY
 aY
 aY
-aP
+qW
 aP
 as
 dU
@@ -24273,11 +24330,11 @@ gY
 gN
 ah
 hE
-hL
+Yw
 as
 hE
 ah
-ah
+RY
 ah
 ia
 id
@@ -24786,7 +24843,7 @@ as
 aP
 aP
 aP
-aY
+Dw
 aY
 aY
 aY
@@ -24860,7 +24917,7 @@ cN
 cN
 et
 et
-ah
+DC
 ah
 as
 fP
@@ -24974,7 +25031,7 @@ aw
 aA
 aj
 ap
-aj
+Us
 as
 aT
 aP
@@ -25181,7 +25238,7 @@ as
 aP
 aP
 aP
-aP
+Yo
 aX
 bI
 bI
@@ -26602,7 +26659,7 @@ cb
 ca
 cz
 cL
-aY
+Gr
 aP
 cO
 dq
@@ -27094,7 +27151,7 @@ ah
 ah
 ah
 ah
-ah
+DC
 gO
 as
 as
@@ -27416,7 +27473,7 @@ dl
 dl
 aY
 aY
-aY
+jx
 dl
 dl
 ed

--- a/maps/away/icarus/icarus-2.dmm
+++ b/maps/away/icarus/icarus-2.dmm
@@ -1139,6 +1139,7 @@
 	icon_state = "tube1"
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meat/strippedhuman,
 /turf/simulated/floor/tiled,
 /area/icarus/vessel)
 "dC" = (
@@ -1898,6 +1899,11 @@
 	},
 /turf/unsimulated/mineral,
 /area/space)
+"kh" = (
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/meat/horrorsmall,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
 "kT" = (
 /obj/machinery/computer/modular{
 	dir = 8
@@ -1916,6 +1922,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/icarus/open)
+"qR" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meat/horrorminer,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"AC" = (
+/mob/living/simple_animal/hostile/meat/horrorminer,
+/turf/simulated/floor/tiled,
+/area/icarus/open)
 "Bd" = (
 /obj/structure/wall_frame,
 /turf/simulated/floor/plating,
@@ -1925,11 +1940,27 @@
 /obj/structure/wall_frame,
 /turf/simulated/floor/plating,
 /area/icarus/vessel)
+"Hu" = (
+/mob/living/simple_animal/hostile/meat/horror,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"PQ" = (
+/mob/living/simple_animal/hostile/meat/horror,
+/turf/simulated/floor/shuttle/white,
+/area/icarus/vessel)
 "RQ" = (
 /obj/machinery/computer/modular{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"TJ" = (
+/mob/living/simple_animal/hostile/meat/humansecurity,
+/turf/simulated/floor/tiled,
+/area/icarus/vessel)
+"Uw" = (
+/mob/living/simple_animal/hostile/meat/abomination,
+/turf/simulated/floor/shuttle/white,
 /area/icarus/vessel)
 "Vb" = (
 /obj/machinery/computer/modular{
@@ -20580,7 +20611,7 @@ bt
 ap
 bU
 ak
-cw
+AC
 cL
 ac
 ac
@@ -21672,7 +21703,7 @@ ak
 ap
 er
 eC
-eC
+PQ
 eV
 eY
 fd
@@ -22391,7 +22422,7 @@ ak
 ak
 ak
 ak
-ak
+TJ
 ak
 bh
 ak
@@ -22585,7 +22616,7 @@ ae
 Fo
 Bd
 ak
-ar
+kh
 ai
 ak
 ak
@@ -23411,7 +23442,7 @@ cm
 cC
 ap
 aM
-ak
+TJ
 ak
 dz
 le
@@ -23810,7 +23841,7 @@ bf
 ap
 ak
 ak
-ak
+Hu
 ak
 ak
 ap
@@ -24205,7 +24236,7 @@ as
 aw
 ak
 ak
-ak
+TJ
 ak
 ak
 ak
@@ -24702,7 +24733,7 @@ ag
 ap
 er
 eC
-eC
+Uw
 eE
 eY
 fd
@@ -24827,7 +24858,7 @@ ak
 ak
 ak
 ai
-ai
+qR
 ai
 cw
 cw
@@ -25018,7 +25049,7 @@ ao
 aI
 aI
 aX
-ak
+Hu
 bo
 ak
 ai
@@ -26644,7 +26675,7 @@ cK
 ap
 dh
 dq
-ak
+TJ
 dz
 dJ
 ap

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -2302,12 +2302,36 @@
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base/supply)
+"jm" = (
+/mob/living/simple_animal/hostile/syndicate/ranged,
+/turf/simulated/floor/shuttle/blue,
+/area/space)
+"jD" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/turf/simulated/floor/tiled/airless,
+/area/lost_supply_base/office)
+"ni" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/tiled/airless,
+/area/lost_supply_base/supply)
+"zy" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/tiled/airless,
+/area/lost_supply_base/common)
+"Cn" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/tiled/airless,
+/area/lost_supply_base)
 "Jd" = (
 /obj/machinery/computer/modular{
 	dir = 1
 	},
 /turf/simulated/floor/shuttle/blue,
 /area/space)
+"Ks" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/airless,
+/area/lost_supply_base)
 
 (1,1,1) = {"
 aa
@@ -6739,7 +6763,7 @@ aa
 dH
 dV
 dS
-dS
+jm
 dS
 eM
 dH
@@ -7951,7 +7975,7 @@ aA
 aH
 bd
 bq
-aG
+Ks
 aG
 bd
 aG
@@ -8167,7 +8191,7 @@ dj
 aG
 aG
 aG
-aG
+Ks
 aG
 aG
 fb
@@ -9083,7 +9107,7 @@ bj
 dp
 bj
 dO
-bj
+Cn
 bj
 bj
 bj
@@ -9396,7 +9420,7 @@ eG
 cv
 fg
 fr
-fs
+ni
 fF
 fp
 fE
@@ -9480,7 +9504,7 @@ aa
 aC
 aT
 bl
-aV
+jD
 bP
 ca
 ck
@@ -9590,7 +9614,7 @@ cz
 cL
 cV
 de
-cK
+zy
 dA
 dP
 dA

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -916,6 +916,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/mob/living/simple_animal/hostile/syndicate/melee/space,
 /turf/simulated/floor/airless,
 /area/magshield/smes_storage)
 "cr" = (
@@ -4359,10 +4360,28 @@
 /obj/effect/shuttle_landmark/nav_magshield/nav3,
 /turf/space,
 /area/space)
+"st" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/tiled,
+/area/magshield/west)
 "uL" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/magshield/west)
+"vA" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/turf/simulated/floor/tiled/dark,
+/area/magshield/west)
+"zz" = (
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/tiled,
+/area/magshield/south)
+"BS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/tiled,
+/area/magshield/south)
 "Eo" = (
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 0;
@@ -4372,6 +4391,39 @@
 	},
 /turf/simulated/floor/airless,
 /area/magshield/east)
+"Mq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/airless,
+/area/magshield/north)
+"Pt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/mob/living/simple_animal/hostile/syndicate/melee/space,
+/turf/simulated/floor/airless,
+/area/magshield/north)
+"Sl" = (
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
+/turf/simulated/floor/airless,
+/area/magshield/north)
 
 (1,1,1) = {"
 aa
@@ -18009,7 +18061,7 @@ gI
 gP
 gW
 fA
-fA
+st
 fA
 hK
 hT
@@ -19622,7 +19674,7 @@ fA
 fA
 fA
 fA
-fB
+vA
 fA
 fA
 fA
@@ -19842,7 +19894,7 @@ iO
 jc
 jc
 jK
-kg
+BS
 kw
 kP
 jd
@@ -22638,7 +22690,7 @@ dp
 dj
 dU
 dj
-ej
+Mq
 dm
 eR
 de
@@ -24692,7 +24744,7 @@ ju
 jw
 kk
 kE
-jd
+zz
 jw
 jw
 ip
@@ -25668,7 +25720,7 @@ dv
 dj
 dj
 dj
-eo
+Pt
 dj
 eU
 de
@@ -28091,7 +28143,7 @@ de
 dB
 dj
 dj
-dj
+Sl
 dj
 eo
 dt

--- a/maps/away/mining/mining-orb.dmm
+++ b/maps/away/mining/mining-orb.dmm
@@ -245,6 +245,10 @@
 	},
 /turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
+"oq" = (
+/mob/living/simple_animal/hostile/faithless,
+/turf/simulated/floor/fixed/alium/airless,
+/area/mine/explored)
 "pz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 10;
@@ -291,6 +295,10 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner,
 /turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
+"CC" = (
+/mob/living/simple_animal/hostile/faithless,
+/turf/simulated/floor/airless/stone,
+/area/mine/explored)
 "DJ" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
@@ -318,6 +326,10 @@
 	dir = 6
 	},
 /turf/simulated/floor/exoplanet/water/shallow,
+/area/mine/explored)
+"Hd" = (
+/mob/living/simple_animal/hostile/faithless,
+/turf/simulated/floor/asteroid,
 /area/mine/explored)
 "Le" = (
 /obj/effect/floor_decal/spline/fancy/wood/corner{
@@ -355,6 +367,14 @@
 /obj/effect/floor_decal/spline/fancy/wood,
 /turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/unexplored)
+"SW" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 1;
+	icon_state = "spline_fancy"
+	},
+/mob/living/simple_animal/hostile/faithless,
+/turf/simulated/floor/exoplanet/water/shallow,
+/area/mine/explored)
 "SY" = (
 /obj/structure/fountain,
 /mob/living/simple_animal/hostile/retaliate/parrot/space,
@@ -14151,7 +14171,7 @@ ag
 ai
 ak
 al
-ak
+oq
 ak
 aj
 ah
@@ -17640,7 +17660,7 @@ aj
 aj
 aj
 aj
-aj
+CC
 aj
 aj
 aj
@@ -17884,7 +17904,7 @@ an
 an
 an
 ap
-aj
+CC
 aj
 aM
 aU
@@ -18093,7 +18113,7 @@ aF
 aP
 ax
 aM
-ak
+oq
 aj
 aj
 aj
@@ -19841,7 +19861,7 @@ am
 am
 am
 ao
-ae
+Hd
 aj
 aj
 aj
@@ -19862,7 +19882,7 @@ ap
 aM
 aj
 aj
-ae
+Hd
 aj
 aj
 aM
@@ -20458,7 +20478,7 @@ aj
 aj
 ae
 ae
-ae
+Hd
 ae
 ao
 an
@@ -21284,7 +21304,7 @@ ae
 aj
 aQ
 aj
-aF
+SW
 ax
 ao
 aF
@@ -22673,7 +22693,7 @@ ae
 aj
 aj
 aj
-ae
+Hd
 aj
 aj
 aj
@@ -22690,7 +22710,7 @@ ap
 aM
 aj
 aj
-ae
+Hd
 aj
 aj
 aM
@@ -24912,7 +24932,7 @@ aj
 aj
 aj
 aj
-aj
+CC
 aj
 aj
 aj

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -1300,6 +1300,11 @@
 /obj/machinery/door/airlock/centcom,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
+"eo" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
+/turf/simulated/floor/tiled/white/airless,
+/area/outpost/abandoned)
 "ep" = (
 /obj/machinery/newscaster,
 /turf/simulated/wall/titanium,
@@ -2573,6 +2578,12 @@
 /obj/effect/shuttle_landmark/away/nav6,
 /turf/simulated/floor/asteroid,
 /area/mine/explored)
+"mJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/tiled/airless,
+/area/outpost/abandoned)
 "nb" = (
 /obj/effect/shuttle_landmark/away/nav5,
 /turf/simulated/floor/asteroid,
@@ -2581,21 +2592,9 @@
 /obj/effect/shuttle_landmark/away/nav4,
 /turf/simulated/floor/asteroid,
 /area/mine/explored)
-"ot" = (
-/mob/living/simple_animal/hostile/meatstation/wormguard,
-/turf/simulated/floor/plating,
-/area/outpost/abandoned)
-"oD" = (
-/mob/living/simple_animal/hostile/meatstation/meatball,
-/turf/simulated/floor/holofloor/tiled/dark,
-/area/outpost/abandoned)
 "pb" = (
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/tiled/freezer,
-/area/outpost/abandoned)
-"pH" = (
-/mob/living/simple_animal/hostile/meatstation/meatball,
-/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -2610,9 +2609,9 @@
 /obj/item/ammo_casing/pistol/magnum,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
-"qz" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/meatstation/meatworm,
+"qk" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
 /turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "rb" = (
@@ -2628,10 +2627,6 @@
 /mob/living/simple_animal/hostile/meatstation/wormguard,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
-"rv" = (
-/mob/living/simple_animal/hostile/meatstation/wormguard,
-/turf/simulated/floor/asteroid,
-/area/mine/explored)
 "sb" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -2647,9 +2642,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
-"sF" = (
+"sZ" = (
 /mob/living/simple_animal/hostile/meatstation/meatworm,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/white/airless,
 /area/outpost/abandoned)
 "tb" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -2665,10 +2660,6 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/diona,
-/area/outpost/abandoned)
-"uy" = (
-/mob/living/simple_animal/hostile/meatstation/wormguard,
-/turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "vb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -2689,15 +2680,20 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/outpost/abandoned)
-"xl" = (
+"wf" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/meatstation/meatball,
-/turf/simulated/floor/tiled/dark,
-/area/outpost/abandoned)
-"xR" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/meatstation/meatworm,
 /turf/simulated/floor/tiled/airless,
+/area/outpost/abandoned)
+"wZ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/plating,
+/area/outpost/abandoned)
+"xs" = (
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/carpet/blue,
 /area/outpost/abandoned)
 "yb" = (
 /obj/item/weapon/storage/mirror{
@@ -2720,43 +2716,30 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
-"yo" = (
-/mob/living/simple_animal/hostile/meatstation/meatball,
-/turf/simulated/floor/carpet/blue,
-/area/outpost/abandoned)
-"Aj" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/meatstation/meatball,
+"Bv" = (
+/mob/living/simple_animal/hostile/meatstation/wormguard,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
-"DJ" = (
-/mob/living/simple_animal/hostile/meatstation/meatmound,
-/turf/simulated/floor/diona,
+"EF" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
-"Ez" = (
-/mob/living/simple_animal/hostile/meatstation/meatworm,
-/turf/simulated/floor/tiled/white/airless,
-/area/outpost/abandoned)
-"Hj" = (
+"GH" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/meatstation/wormscientist,
-/turf/simulated/floor/tiled/white/airless,
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/white,
+/area/outpost/abandoned)
+"Hx" = (
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/holofloor/tiled/dark,
 /area/outpost/abandoned)
 "HD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/airless,
-/area/outpost/abandoned)
-"HX" = (
-/obj/effect/floor_decal/corner/purple{
-	dir = 10
-	},
-/mob/living/simple_animal/hostile/meatstation/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/outpost/abandoned)
-"Ip" = (
-/mob/living/simple_animal/hostile/meatstation/wormguard,
-/turf/simulated/floor/holofloor/tiled/dark,
 /area/outpost/abandoned)
 "IX" = (
 /obj/machinery/door/firedoor,
@@ -2764,40 +2747,57 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
-"JB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/meatstation/meatball,
-/turf/simulated/floor/tiled/airless,
-/area/outpost/abandoned)
-"ND" = (
+"JZ" = (
 /mob/living/simple_animal/hostile/meatstation/meatball,
 /turf/simulated/floor/tiled,
 /area/outpost/abandoned)
-"Pf" = (
+"Lx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/tiled/dark,
+/area/outpost/abandoned)
+"LC" = (
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/outpost/abandoned)
+"Nf" = (
 /mob/living/simple_animal/hostile/meatstation/wormguard,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
-"Pw" = (
-/obj/effect/floor_decal/corner/purple{
-	dir = 10
-	},
+"PG" = (
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/dark,
+/area/outpost/abandoned)
+"QA" = (
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/asteroid,
+/area/mine/explored)
+"SQ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/airless,
+/area/outpost/abandoned)
+"TP" = (
+/mob/living/simple_animal/hostile/meatstation/meatmound,
+/turf/simulated/floor/diona,
+/area/outpost/abandoned)
+"Ug" = (
 /mob/living/simple_animal/hostile/meatstation/meatball,
 /turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
-"Ta" = (
-/obj/effect/floor_decal/corner/paleblue/diagonal,
-/mob/living/simple_animal/hostile/meatstation/wormscientist,
-/turf/simulated/floor/tiled/white,
-/area/outpost/abandoned)
-"Te" = (
+"XK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/corner/purple{
 	dir = 10
 	},
 /mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/white,
+/area/outpost/abandoned)
+"XN" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
 /turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 
@@ -12194,7 +12194,7 @@ af
 dE
 cW
 dD
-Hj
+eo
 fm
 dD
 cG
@@ -12801,7 +12801,7 @@ dG
 dW
 eu
 dW
-Ez
+sZ
 dD
 af
 aa
@@ -13618,7 +13618,7 @@ aH
 gu
 aH
 aS
-ot
+Bv
 aH
 hg
 fW
@@ -13817,7 +13817,7 @@ af
 aa
 af
 gu
-Aj
+wZ
 gu
 gu
 aH
@@ -14417,7 +14417,7 @@ dJ
 cW
 ez
 eW
-xR
+SQ
 fL
 af
 aa
@@ -15210,7 +15210,7 @@ aa
 af
 ax
 aK
-Ta
+qk
 az
 af
 bs
@@ -15223,7 +15223,7 @@ db
 af
 dN
 cW
-Pf
+mJ
 eZ
 fv
 fN
@@ -16017,7 +16017,7 @@ aa
 aa
 af
 aB
-DJ
+TP
 aA
 az
 bm
@@ -16033,7 +16033,7 @@ dQ
 ee
 eB
 fb
-JB
+wf
 fQ
 dH
 dH
@@ -16225,7 +16225,7 @@ az
 af
 bx
 bJ
-HX
+XN
 af
 af
 cG
@@ -16240,7 +16240,7 @@ cw
 cW
 cW
 gm
-uy
+Nf
 gE
 gL
 gO
@@ -17235,7 +17235,7 @@ af
 af
 bu
 bJ
-Te
+XK
 af
 af
 af
@@ -17432,7 +17432,7 @@ aj
 ao
 ao
 af
-Ip
+LC
 ao
 af
 bB
@@ -17647,7 +17647,7 @@ dh
 dw
 dm
 ab
-rv
+QA
 ab
 ab
 ab
@@ -17657,7 +17657,7 @@ ej
 ej
 ab
 ab
-rv
+QA
 ab
 ab
 ab
@@ -17837,7 +17837,7 @@ ao
 ao
 af
 bc
-oD
+Hx
 af
 bC
 bL
@@ -19052,7 +19052,7 @@ aI
 aI
 bo
 by
-pH
+Ug
 bU
 af
 aa
@@ -19452,7 +19452,7 @@ aa
 aa
 af
 aI
-ND
+JZ
 aI
 bo
 bx
@@ -19658,7 +19658,7 @@ aI
 bk
 af
 bx
-qz
+GH
 bV
 af
 aa
@@ -20472,13 +20472,13 @@ aA
 af
 cP
 do
-yo
+xs
 cQ
 af
 eL
 fh
 fh
-xl
+Lx
 af
 aa
 aa
@@ -21276,14 +21276,14 @@ bq
 bE
 bJ
 bJ
-Pw
+EF
 af
 cR
 dp
 dC
 dT
 dT
-sF
+PG
 fj
 fB
 fV
@@ -21473,7 +21473,7 @@ av
 aI
 aI
 aH
-ND
+JZ
 af
 bF
 aH

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -749,6 +749,7 @@
 	dir = 6;
 	icon_state = "corner_white"
 	},
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
 /turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "cy" = (
@@ -766,6 +767,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
 /turf/simulated/floor/wood,
 /area/outpost/abandoned)
 "cI" = (
@@ -798,6 +800,7 @@
 	dir = 4;
 	icon_state = "spline_fancy"
 	},
+/mob/living/simple_animal/hostile/meatstation/meatworm,
 /turf/simulated/floor/wood,
 /area/outpost/abandoned)
 "cN" = (
@@ -1871,6 +1874,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 8
 	},
+/mob/living/simple_animal/hostile/meatstation/wormguard,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
 "fW" = (
@@ -2577,9 +2581,21 @@
 /obj/effect/shuttle_landmark/away/nav4,
 /turf/simulated/floor/asteroid,
 /area/mine/explored)
+"ot" = (
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/plating,
+/area/outpost/abandoned)
+"oD" = (
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/holofloor/tiled/dark,
+/area/outpost/abandoned)
 "pb" = (
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/tiled/freezer,
+/area/outpost/abandoned)
+"pH" = (
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "qb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -2594,6 +2610,11 @@
 /obj/item/ammo_casing/pistol/magnum,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
+"qz" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/white,
+/area/outpost/abandoned)
 "rb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4;
@@ -2604,8 +2625,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/pistol/magnum,
+/mob/living/simple_animal/hostile/meatstation/wormguard,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
+"rv" = (
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/asteroid,
+/area/mine/explored)
 "sb" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -2619,6 +2645,10 @@
 /obj/machinery/button/blast_door{
 	id_tag = "mars_blast"
 	},
+/turf/simulated/floor/tiled/dark,
+/area/outpost/abandoned)
+"sF" = (
+/mob/living/simple_animal/hostile/meatstation/meatworm,
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
 "tb" = (
@@ -2635,6 +2665,10 @@
 	icon_state = "intact"
 	},
 /turf/simulated/floor/diona,
+/area/outpost/abandoned)
+"uy" = (
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "vb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
@@ -2654,6 +2688,16 @@
 	icon_state = "console"
 	},
 /turf/simulated/floor/carpet/blue,
+/area/outpost/abandoned)
+"xl" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/tiled/dark,
+/area/outpost/abandoned)
+"xR" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/airless,
 /area/outpost/abandoned)
 "yb" = (
 /obj/item/weapon/storage/mirror{
@@ -2676,16 +2720,85 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
+"yo" = (
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/carpet/blue,
+/area/outpost/abandoned)
+"Aj" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/plating,
+/area/outpost/abandoned)
+"DJ" = (
+/mob/living/simple_animal/hostile/meatstation/meatmound,
+/turf/simulated/floor/diona,
+/area/outpost/abandoned)
+"Ez" = (
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/white/airless,
+/area/outpost/abandoned)
+"Hj" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
+/turf/simulated/floor/tiled/white/airless,
+/area/outpost/abandoned)
 "HD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white/airless,
+/area/outpost/abandoned)
+"HX" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
+/turf/simulated/floor/tiled/white,
+/area/outpost/abandoned)
+"Ip" = (
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/holofloor/tiled/dark,
 /area/outpost/abandoned)
 "IX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open,
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
+/area/outpost/abandoned)
+"JB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/tiled/airless,
+/area/outpost/abandoned)
+"ND" = (
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/tiled,
+/area/outpost/abandoned)
+"Pf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/meatstation/wormguard,
+/turf/simulated/floor/tiled/airless,
+/area/outpost/abandoned)
+"Pw" = (
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/meatstation/meatball,
+/turf/simulated/floor/tiled/white,
+/area/outpost/abandoned)
+"Ta" = (
+/obj/effect/floor_decal/corner/paleblue/diagonal,
+/mob/living/simple_animal/hostile/meatstation/wormscientist,
+/turf/simulated/floor/tiled/white,
+/area/outpost/abandoned)
+"Te" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/purple{
+	dir = 10
+	},
+/mob/living/simple_animal/hostile/meatstation/meatworm,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 
 (1,1,1) = {"
@@ -12081,7 +12194,7 @@ af
 dE
 cW
 dD
-dW
+Hj
 fm
 dD
 cG
@@ -12688,7 +12801,7 @@ dG
 dW
 eu
 dW
-dD
+Ez
 dD
 af
 aa
@@ -13505,7 +13618,7 @@ aH
 gu
 aH
 aS
-aH
+ot
 aH
 hg
 fW
@@ -13704,7 +13817,7 @@ af
 aa
 af
 gu
-gu
+Aj
 gu
 gu
 aH
@@ -14304,7 +14417,7 @@ dJ
 cW
 ez
 eW
-cW
+xR
 fL
 af
 aa
@@ -15097,7 +15210,7 @@ aa
 af
 ax
 aK
-az
+Ta
 az
 af
 bs
@@ -15110,7 +15223,7 @@ db
 af
 dN
 cW
-cw
+Pf
 eZ
 fv
 fN
@@ -15904,7 +16017,7 @@ aa
 aa
 af
 aB
-aA
+DJ
 aA
 az
 bm
@@ -15920,7 +16033,7 @@ dQ
 ee
 eB
 fb
-cw
+JB
 fQ
 dH
 dH
@@ -16112,7 +16225,7 @@ az
 af
 bx
 bJ
-bP
+HX
 af
 af
 cG
@@ -16127,7 +16240,7 @@ cw
 cW
 cW
 gm
-dH
+uy
 gE
 gL
 gO
@@ -17122,7 +17235,7 @@ af
 af
 bu
 bJ
-bQ
+Te
 af
 af
 af
@@ -17319,7 +17432,7 @@ aj
 ao
 ao
 af
-ao
+Ip
 ao
 af
 bB
@@ -17534,7 +17647,7 @@ dh
 dw
 dm
 ab
-ab
+rv
 ab
 ab
 ab
@@ -17544,7 +17657,7 @@ ej
 ej
 ab
 ab
-ab
+rv
 ab
 ab
 ab
@@ -17724,7 +17837,7 @@ ao
 ao
 af
 bc
-ao
+oD
 af
 bC
 bL
@@ -18939,7 +19052,7 @@ aI
 aI
 bo
 by
-bH
+pH
 bU
 af
 aa
@@ -19339,7 +19452,7 @@ aa
 aa
 af
 aI
-aI
+ND
 aI
 bo
 bx
@@ -19545,7 +19658,7 @@ aI
 bk
 af
 bx
-bJ
+qz
 bV
 af
 aa
@@ -20359,13 +20472,13 @@ aA
 af
 cP
 do
-cQ
+yo
 cQ
 af
 eL
 fh
 fh
-eL
+xl
 af
 aa
 aa
@@ -21163,14 +21276,14 @@ bq
 bE
 bJ
 bJ
-bP
+Pw
 af
 cR
 dp
 dC
 dT
 dT
-dT
+sF
 fj
 fB
 fV
@@ -21360,7 +21473,7 @@ av
 aI
 aI
 aH
-aI
+ND
 af
 bF
 aH

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -1055,6 +1055,15 @@
 /obj/random/soap,
 /turf/simulated/floor/airless/ceiling,
 /area/smugglers/dorms)
+"xq" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/russian/ranged,
+/turf/simulated/floor/tiled,
+/area/smugglers/dorms)
+"XX" = (
+/mob/living/simple_animal/hostile/russian,
+/turf/simulated/floor,
+/area/smugglers/base)
 
 (1,1,1) = {"
 aa
@@ -4358,7 +4367,7 @@ bh
 br
 by
 bF
-bd
+XX
 bR
 cc
 cf
@@ -4566,7 +4575,7 @@ bd
 bT
 cc
 ch
-cm
+xq
 cu
 cc
 cy

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -75,7 +75,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/giant_spider/hunter,
+/mob/living/simple_animal/hostile/giant_spider/guard,
 /turf/simulated/floor/wood/walnut,
 /area/yacht/bridge)
 "ao" = (
@@ -1105,6 +1105,7 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/giant_spider/nurse,
 /turf/simulated/floor/plating,
 /area/yacht/engine)
 "do" = (
@@ -1484,6 +1485,11 @@
 "xB" = (
 /turf/simulated/wall/walnut,
 /area/yacht/living)
+"CE" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/giant_spider/spitter,
+/turf/simulated/floor/wood/yew,
+/area/yacht/living)
 "Hj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
@@ -1498,6 +1504,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood/yew,
 /area/yacht/living)
+"WY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4;
+	icon_state = "map_universal"
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/giant_spider/nurse,
+/turf/simulated/floor/plating,
+/area/yacht/engine)
 
 (1,1,1) = {"
 aa
@@ -6632,7 +6647,7 @@ at
 ax
 aF
 aL
-aL
+CE
 aY
 aL
 aL
@@ -7051,7 +7066,7 @@ aB
 bN
 ca
 cn
-cn
+WY
 ub
 bN
 dg

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/contents_1.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/contents_1.dmm
@@ -33,6 +33,10 @@
 /obj/structure/foamedmetal,
 /turf/template_noop,
 /area/template_noop)
+"t" = (
+/mob/living/simple_animal/hostile/meat/abomination,
+/turf/template_noop,
+/area/template_noop)
 
 (1,1,1) = {"
 c
@@ -43,7 +47,7 @@ a
 (2,1,1) = {"
 c
 b
-b
+t
 c
 "}
 (3,1,1) = {"

--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dmm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dmm
@@ -2157,6 +2157,14 @@
 /obj/effect/landmark/scorcher,
 /turf/template_noop,
 /area/template_noop)
+"DH" = (
+/mob/living/simple_animal/hostile/meat/horrorminer,
+/turf/simulated/floor/tiled/white/lowpressure,
+/area/map_template/ecship/cryo)
+"DY" = (
+/mob/living/simple_animal/hostile/meat/humansecurity,
+/turf/simulated/floor,
+/area/map_template/ecship/engineering)
 "NM" = (
 /obj/effect/landmark/scorcher,
 /turf/template_noop,
@@ -2176,6 +2184,10 @@
 "Vy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/weapon/circular_saw,
+/turf/simulated/floor/tiled/white/lowpressure,
+/area/map_template/ecship/science)
+"Xf" = (
+/mob/living/simple_animal/hostile/meat/strippedhuman,
 /turf/simulated/floor/tiled/white/lowpressure,
 /area/map_template/ecship/science)
 "YW" = (
@@ -2384,7 +2396,7 @@ aJ
 bI
 bs
 co
-bJ
+Xf
 cE
 ao
 aB
@@ -2930,7 +2942,7 @@ cK
 cP
 cU
 cP
-cU
+DY
 dq
 dD
 dd
@@ -3496,7 +3508,7 @@ as
 aH
 aV
 aV
-aV
+DH
 bv
 as
 ab

--- a/maps/random_ruins/exoplanet_ruins/hut/hut.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hut/hut.dmm
@@ -72,6 +72,7 @@
 /area/template_noop)
 "q" = (
 /obj/item/weapon/pen/multi,
+/mob/living/simple_animal/hostile/pirate/ranged,
 /turf/simulated/floor/tiled/dark,
 /area/template_noop)
 "r" = (

--- a/maps/random_ruins/exoplanet_ruins/lodge/lodge.dmm
+++ b/maps/random_ruins/exoplanet_ruins/lodge/lodge.dmm
@@ -238,10 +238,21 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/wood,
 /area/template_noop)
+"R" = (
+/obj/effect/floor_decal/spline/fancy/wood{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/pirate/ranged,
+/turf/simulated/floor/tiled/monotile,
+/area/template_noop)
 "S" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/floor_decal/spline/fancy/wood/corner,
 /turf/simulated/floor/wood,
+/area/template_noop)
+"Y" = (
+/mob/living/simple_animal/hostile/pirate,
+/turf/simulated/floor/tiled/monotile,
 /area/template_noop)
 
 (1,1,1) = {"
@@ -275,7 +286,7 @@ b
 b
 b
 b
-u
+R
 D
 b
 a
@@ -365,7 +376,7 @@ a
 a
 g
 l
-t
+Y
 y
 F
 g

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dmm
@@ -1161,6 +1161,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/mob/living/simple_animal/hostile/giant_spider/spitter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab/station/southairlock)
 "rS" = (
@@ -1277,6 +1278,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/mob/living/simple_animal/hostile/giant_spider/guard,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab/station/chem)
 "uy" = (
@@ -1867,6 +1869,13 @@
 "Fj" = (
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab/station/chem)
+"Fq" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/giant_spider/nurse,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/oldlab/station/northairlockatmos)
 "Ft" = (
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -3017,6 +3026,17 @@
 /obj/machinery/smartfridge/chemistry,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab/station/chem)
+"YU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
+/mob/living/simple_animal/hostile/giant_spider/guard,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab/station/hall)
 "YW" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 6
@@ -3504,7 +3524,7 @@ YZ
 QE
 TV
 ke
-DK
+Fq
 KS
 hP
 sj
@@ -3747,7 +3767,7 @@ As
 zR
 Cv
 Gv
-Sp
+YU
 ob
 Ln
 PL

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -600,6 +600,10 @@
 /obj/structure/closet/crate/secure/biohazard/alt,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/server)
+"dF" = (
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/Engineering)
 "dH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -1045,6 +1049,16 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/Airlock)
+"fw" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/syndicate/melee,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/mess)
 "fy" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -1376,6 +1390,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/recandlockers)
 "hw" = (
@@ -1512,6 +1527,7 @@
 /area/map_template/oldlab2/mess)
 "ih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/server)
 "ik" = (
@@ -1761,6 +1777,7 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated,
+/mob/living/simple_animal/hostile/viscerator,
 /turf/simulated/floor/plating,
 /area/map_template/oldlab2/powerandatmos)
 "jY" = (
@@ -2330,6 +2347,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab2/office)
+"ni" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/Airlock)
 "nj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -3099,6 +3123,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/mob/living/simple_animal/hostile/syndicate/ranged/space,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/fixedsecurity)
 "rd" = (
@@ -4389,6 +4414,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/syndicate/melee,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/mess)
 "xf" = (
@@ -4538,6 +4564,16 @@
 "xZ" = (
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living5)
+"yc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/viscerator,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/hall)
 "yd" = (
 /obj/machinery/vending/assist{
 	dir = 8
@@ -4838,6 +4874,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/powerandatmos)
 "zT" = (
@@ -5121,6 +5158,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/mob/living/simple_animal/hostile/rogue_drone,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/server)
 "Bd" = (
@@ -5462,6 +5500,15 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/oldlab2/bathroom)
+"Da" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/server)
 "Dc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/closet/emcloset,
@@ -5816,6 +5863,10 @@
 /obj/item/weapon/bedsheet/hop,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living6)
+"Es" = (
+/mob/living/simple_animal/hostile/creature,
+/turf/simulated/floor/reinforced,
+/area/map_template/oldlab2/test1)
 "Et" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -6555,6 +6606,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/mob/living/simple_animal/hostile/viscerator,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/cso)
 "Ic" = (
@@ -8287,11 +8339,19 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/recandlockers)
+"Rg" = (
+/mob/living/simple_animal/hostile/syndicate/ranged,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/recandlockers)
 "Ro" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/walnut,
 /area/map_template/oldlab2/recandlockers)
+"Rq" = (
+/mob/living/simple_animal/hostile/syndicate/melee,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/medical)
 "Rs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -8640,6 +8700,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated,
+/mob/living/simple_animal/hostile/syndicate/melee,
 /turf/simulated/floor/plating,
 /area/map_template/oldlab2/engineerhall)
 "Tu" = (
@@ -8818,6 +8879,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/lab)
 "Ut" = (
@@ -8900,6 +8962,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/chem)
+"UR" = (
+/mob/living/simple_animal/hostile/syndicate/melee,
+/turf/simulated/floor/carpet,
+/area/map_template/oldlab2/recandlockers)
 "UV" = (
 /obj/structure/filingcabinet/filingcabinet,
 /obj/structure/filingcabinet/filingcabinet{
@@ -8913,6 +8979,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/server)
+"UY" = (
+/obj/effect/floor_decal/corner/research{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/research{
+	dir = 6
+	},
+/mob/living/simple_animal/hostile/syndicate/melee,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/lab)
 "UZ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -9156,6 +9237,21 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living5)
+"Wr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/viscerator,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/office)
 "Wu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -9616,6 +9712,11 @@
 "Yz" = (
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/test1)
+"YB" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/Airlock)
 "YD" = (
 /obj/machinery/artifact_harvester,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -10027,7 +10128,7 @@ Pv
 Mk
 Jj
 Qu
-kR
+Da
 GL
 Qu
 GL
@@ -10202,7 +10303,7 @@ Ma
 dp
 BH
 BH
-BH
+Es
 GX
 yZ
 YN
@@ -10224,7 +10325,7 @@ bf
 JG
 nx
 Hi
-cm
+yc
 Ud
 eT
 zC
@@ -10423,7 +10524,7 @@ KH
 XR
 Of
 gG
-Of
+UY
 Ox
 Of
 cY
@@ -10648,7 +10749,7 @@ Am
 OT
 vp
 Am
-Am
+Rq
 NQ
 Am
 PD
@@ -10739,7 +10840,7 @@ bm
 xD
 Hp
 yz
-Qs
+Wr
 XL
 XL
 nx
@@ -11013,7 +11114,7 @@ mG
 Rc
 Mg
 hD
-XJ
+fw
 kj
 hD
 hD
@@ -11052,7 +11153,7 @@ yB
 Rs
 rm
 eb
-Tb
+dF
 zu
 nx
 nK
@@ -11790,7 +11891,7 @@ pT
 BU
 gg
 oB
-oB
+Rg
 WW
 WW
 qu
@@ -11974,7 +12075,7 @@ Nz
 Nz
 iU
 Li
-tE
+YB
 NG
 UZ
 Mh
@@ -12033,7 +12134,7 @@ vA
 gg
 hE
 Qg
-Yi
+UR
 Yi
 gg
 Um
@@ -12132,7 +12233,7 @@ gb
 Li
 tE
 NG
-UZ
+ni
 dI
 gg
 Uo

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -224,6 +224,10 @@
 /obj/item/weapon/bedsheet/brown,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living4)
+"bC" = (
+/mob/living/simple_animal/hostile/syndicate/melee,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/medical)
 "bD" = (
 /turf/simulated/wall/titanium,
 /area/map_template/oldlab2/living2)
@@ -600,10 +604,6 @@
 /obj/structure/closet/crate/secure/biohazard/alt,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/server)
-"dF" = (
-/mob/living/simple_animal/hostile/rogue_drone,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/oldlab2/Engineering)
 "dH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -1049,16 +1049,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/Airlock)
-"fw" = (
-/obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/syndicate/melee,
-/turf/simulated/floor/tiled/white,
-/area/map_template/oldlab2/mess)
 "fy" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -1654,6 +1644,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/engineerhall)
+"jq" = (
+/mob/living/simple_animal/hostile/syndicate/ranged,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/recandlockers)
 "jr" = (
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/recandlockers)
@@ -2314,6 +2308,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/office)
+"na" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/viscerator,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/hall)
 "nd" = (
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/techfloor,
@@ -2347,13 +2351,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab2/office)
-"ni" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/rogue_drone,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/oldlab2/Airlock)
 "nj" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -3201,6 +3198,16 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/test1)
+"rq" = (
+/obj/effect/floor_decal/corner/blue/diagonal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/syndicate/melee,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/mess)
 "rs" = (
 /obj/machinery/access_button{
 	active_power_usage = "oldlab_airlock";
@@ -3841,6 +3848,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/oldlab2/fixedsecurity)
+"tZ" = (
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/Airlock)
 "ue" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4316,6 +4330,10 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/oldlab2/bathroom)
+"ww" = (
+/mob/living/simple_animal/hostile/creature,
+/turf/simulated/floor/reinforced,
+/area/map_template/oldlab2/test1)
 "wC" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4564,16 +4582,6 @@
 "xZ" = (
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living5)
-"yc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/viscerator,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/oldlab2/hall)
 "yd" = (
 /obj/machinery/vending/assist{
 	dir = 8
@@ -5500,15 +5508,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/oldlab2/bathroom)
-"Da" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/hostile/rogue_drone,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/oldlab2/server)
 "Dc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/closet/emcloset,
@@ -5863,10 +5862,6 @@
 /obj/item/weapon/bedsheet/hop,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living6)
-"Es" = (
-/mob/living/simple_animal/hostile/creature,
-/turf/simulated/floor/reinforced,
-/area/map_template/oldlab2/test1)
 "Et" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -6059,6 +6054,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/medical)
+"Fc" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/server)
 "Fd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6880,6 +6884,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/test1)
+"Jt" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/Airlock)
 "Jv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -7439,6 +7448,10 @@
 /mob/living/exosuit/premade/powerloader/old,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/oldlab2/Airlock)
+"MA" = (
+/mob/living/simple_animal/hostile/syndicate/melee,
+/turf/simulated/floor/carpet,
+/area/map_template/oldlab2/recandlockers)
 "MC" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/airlock_sensor{
@@ -8339,19 +8352,11 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/recandlockers)
-"Rg" = (
-/mob/living/simple_animal/hostile/syndicate/ranged,
-/turf/simulated/floor/tiled/white,
-/area/map_template/oldlab2/recandlockers)
 "Ro" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood/walnut,
 /area/map_template/oldlab2/recandlockers)
-"Rq" = (
-/mob/living/simple_animal/hostile/syndicate/melee,
-/turf/simulated/floor/tiled/white,
-/area/map_template/oldlab2/medical)
 "Rs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -8962,24 +8967,7 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/chem)
-"UR" = (
-/mob/living/simple_animal/hostile/syndicate/melee,
-/turf/simulated/floor/carpet,
-/area/map_template/oldlab2/recandlockers)
-"UV" = (
-/obj/structure/filingcabinet/filingcabinet,
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = 10
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/map_template/oldlab2/server)
-"UY" = (
+"UK" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 9
 	},
@@ -8994,6 +8982,19 @@
 /mob/living/simple_animal/hostile/syndicate/melee,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/lab)
+"UV" = (
+/obj/structure/filingcabinet/filingcabinet,
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = 10
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/server)
 "UZ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -9237,21 +9238,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living5)
-"Wr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/mob/living/simple_animal/hostile/viscerator,
-/turf/simulated/floor/tiled/white,
-/area/map_template/oldlab2/office)
 "Wu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -9336,6 +9322,10 @@
 /obj/item/weapon/bedsheet/hop,
 /turf/simulated/floor/tiled/dark,
 /area/map_template/oldlab2/living)
+"WK" = (
+/mob/living/simple_animal/hostile/rogue_drone,
+/turf/simulated/floor/tiled/techfloor,
+/area/map_template/oldlab2/Engineering)
 "WL" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/window/reinforced{
@@ -9651,6 +9641,21 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/mess)
+"Yh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/hostile/viscerator,
+/turf/simulated/floor/tiled/white,
+/area/map_template/oldlab2/office)
 "Yi" = (
 /turf/simulated/floor/carpet,
 /area/map_template/oldlab2/recandlockers)
@@ -9712,11 +9717,6 @@
 "Yz" = (
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/test1)
-"YB" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
-/mob/living/simple_animal/hostile/rogue_drone,
-/turf/simulated/floor/tiled/techfloor,
-/area/map_template/oldlab2/Airlock)
 "YD" = (
 /obj/machinery/artifact_harvester,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -10128,7 +10128,7 @@ Pv
 Mk
 Jj
 Qu
-Da
+Fc
 GL
 Qu
 GL
@@ -10303,7 +10303,7 @@ Ma
 dp
 BH
 BH
-Es
+ww
 GX
 yZ
 YN
@@ -10325,7 +10325,7 @@ bf
 JG
 nx
 Hi
-yc
+na
 Ud
 eT
 zC
@@ -10524,7 +10524,7 @@ KH
 XR
 Of
 gG
-UY
+UK
 Ox
 Of
 cY
@@ -10749,7 +10749,7 @@ Am
 OT
 vp
 Am
-Rq
+bC
 NQ
 Am
 PD
@@ -10840,7 +10840,7 @@ bm
 xD
 Hp
 yz
-Wr
+Yh
 XL
 XL
 nx
@@ -11114,7 +11114,7 @@ mG
 Rc
 Mg
 hD
-fw
+rq
 kj
 hD
 hD
@@ -11153,7 +11153,7 @@ yB
 Rs
 rm
 eb
-dF
+WK
 zu
 nx
 nK
@@ -11891,7 +11891,7 @@ pT
 BU
 gg
 oB
-Rg
+jq
 WW
 WW
 qu
@@ -12075,7 +12075,7 @@ Nz
 Nz
 iU
 Li
-YB
+Jt
 NG
 UZ
 Mh
@@ -12134,7 +12134,7 @@ vA
 gg
 hE
 Qg
-UR
+MA
 Yi
 gg
 Um
@@ -12233,7 +12233,7 @@ gb
 Li
 tE
 NG
-ni
+tZ
 dI
 gg
 Uo

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -135,6 +135,7 @@
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/carp/holodeck,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "at" = (
@@ -430,6 +431,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/carp/pike,
 /turf/simulated/floor/tiled/white/monotile,
 /area/map_template/oldpod)
 "aZ" = (
@@ -517,6 +519,12 @@
 	dir = 6
 	},
 /area/map_template/oldpod)
+"KR" = (
+/obj/effect/decal/cleanable/filth,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/carp/holodeck,
+/turf/simulated/floor/tiled/monotile,
+/area/map_template/oldpod)
 
 (1,1,1) = {"
 aa
@@ -580,7 +588,7 @@ ad
 "}
 (6,1,1) = {"
 ae
-ai
+KR
 an
 av
 aC

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dmm
@@ -88,6 +88,7 @@
 "an" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/carp,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "ao" = (
@@ -189,6 +190,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/carp,
 /turf/simulated/floor/tiled/monotile,
 /area/map_template/oldpod)
 "aA" = (
@@ -519,7 +521,7 @@
 	dir = 6
 	},
 /area/map_template/oldpod)
-"KR" = (
+"WF" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/carp/holodeck,
@@ -588,7 +590,7 @@ ad
 "}
 (6,1,1) = {"
 ae
-KR
+WF
 an
 av
 aC

--- a/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dmm
+++ b/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dmm
@@ -29,6 +29,10 @@
 /obj/machinery/artifact,
 /turf/simulated/floor/reinforced,
 /area/template_noop)
+"D" = (
+/mob/living/simple_animal/hostile/creature,
+/turf/simulated/floor/carpet/red,
+/area/template_noop)
 "I" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/carpet/red,
@@ -65,7 +69,7 @@ b
 c
 f
 f
-f
+D
 h
 i
 d


### PR DESCRIPTION
## ¿Qué hace este PR?
Añade unos cuantos enemigos en la mayoria de estructuras (por ahora unas 17) que se pueden encontrar en el espacio/planetas. Sin que sea imposible pero para que sea un poco mas interesante.

## ¿Por qué es bueno para el juego?
Para que las estructuras del espacio/palnetas no esten tan vacias como ahora y sean mas interesantes de explorar.

## Changelog
:cl:
**add:** Piratas en el casino.
**add:** Horros en el Icarus estrellado.
**add:** Sindies en la nave de suministros destruida.
**add:** Sindies en Magshield.
**add:** Faithless en Mololito de asteroide.
**add:** Horros en estacion minera.
**add:** Rusos en almacen de asteroide.
**add:** Unas cuantas mas arañas en el yate a la deriba.
**add:** Horror en uno de los pods estrellados.
**add:** Horrors en nave estrellada.
**add:** Pirata en una casita (Hut).
**add:** Piratas en otra casa (Lodge).
**add:** Mas arañitas en Oldlab1.
**add:** Sindies en Oldlab2.
**add:** Carpas en pod estrellado.
**add:** Monstruo en... iglesia? (radshrine)
/:cl: