### PR TITLE
Conjunto de Mimo y Payaso en el loadout (Propuesta)

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -65,3 +65,7 @@
 	display_name = "high heels, colour select"
 	path = /obj/item/clothing/shoes/heels
 	flags = GEAR_HAS_COLOR_SELECTION
+
+/datum/gear/shoes/clown
+	display_name = "zapatos de payaso"
+	path = /obj/item/clothing/shoes/clown_shoes

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -183,3 +183,15 @@
 	options += /obj/item/clothing/head/beret/saare
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(options)
 */
+
+/datum/gear/head/clown
+	display_name = "mascara de payaso"
+	path = /obj/item/clothing/mask/gas/clown_hat
+
+/datum/gear/head/mime
+	display_name = "mascara de mimo"
+	path = /obj/item/clothing/mask/gas/mime
+
+/datum/gear/head/mimeberet
+	display_name = "boina de mimo"
+	path = /obj/item/clothing/head/beret

--- a/code/modules/client/preference_setup/loadout/lists/storage.dm
+++ b/code/modules/client/preference_setup/loadout/lists/storage.dm
@@ -69,3 +69,11 @@
 	display_name = "wallet, polychromic"
 	path = /obj/item/weapon/storage/wallet/poly
 	cost = 2
+
+/datum/gear/storage/clown
+	display_name = "mochila de payaso"
+	path = /obj/item/weapon/storage/backpack/clown
+
+/datum/gear/storage/mime
+	display_name = "tirantes de mimo"
+	path = /obj/item/clothing/accessory/suspenders

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -203,3 +203,11 @@
 /datum/gear/uniform/frontier
 	display_name = "frontier clothes"
 	path = /obj/item/clothing/under/frontier
+
+/datum/gear/uniform/clown
+	display_name = "traje de payaso"
+	path = /obj/item/clothing/under/rank/clown
+
+/datum/gear/uniform/mime
+	display_name = "traje de mimo"
+	path = /obj/item/clothing/under/mime

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -98,6 +98,14 @@ modular computers
 	path = /obj/item/modular_computer/laptop/preset/custom_loadout/advanced
 	cost = 6
 
+/datum/gear/utility/clown
+	display_name = "corneta"
+	path = /obj/item/weapon/bikehorn
+
+/datum/gear/utility/mimo
+	display_name = "crayon de mimo"
+	path = /obj/item/weapon/pen/crayon/mime
+
 /****************
 Pouches and kits
 ****************/

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -116,10 +116,19 @@
 
 /datum/gear/head/corporateberet
 	allowed_branches = CIVILIAN_BRANCHES
-	
+
 /datum/gear/head/nursehat
 	display_name = "Nurses Hat"
 	description = "A small white hat with a blue medical cross on the front, worn by nursing staff."
 	path = /obj/item/clothing/head/nursehat
 	allowed_roles = MEDICAL_ROLES
 	allowed_branches = list(/datum/mil_branch/fleet,/datum/mil_branch/marine_corps,/datum/mil_branch/civilian)
+
+/datum/gear/head/clown
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/head/mime
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/head/mimeberet
+	allowed_branches = CIVILIAN_BRANCHES

--- a/maps/torch/loadout/loadout_shoes.dm
+++ b/maps/torch/loadout/loadout_shoes.dm
@@ -28,3 +28,6 @@
 
 /datum/gear/shoes/boots
 	//allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/shoes/clown
+	allowed_branches = CIVILIAN_BRANCHES

--- a/maps/torch/loadout/loadout_storage.dm
+++ b/maps/torch/loadout/loadout_storage.dm
@@ -9,3 +9,9 @@
 	path = /obj/item/clothing/accessory/storage/drop_pouches/black
 	cost = 3
 //	allowed_roles = list(/datum/job/hos, /datum/job/warden, /datum/job/detective, /datum/job/officer, /datum/job/bodyguard)
+
+/datum/gear/storage/clown
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/storage/mime
+	allowed_branches = CIVILIAN_BRANCHES

--- a/maps/torch/loadout/loadout_uniform.dm
+++ b/maps/torch/loadout/loadout_uniform.dm
@@ -81,3 +81,9 @@
 
 /datum/gear/uniform/corp_exec_jacket
 	allowed_roles = list(/datum/job/liaison, /datum/job/bodyguard)
+
+/datum/gear/uniform/clown
+	allowed_branches = CIVILIAN_BRANCHES
+
+/datum/gear/uniform/mime
+	allowed_branches = CIVILIAN_BRANCHES


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega al loadout todo el conjunto de Mimo y del Payaso en su respectiva categoria, para trabajos CIVILES.

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/105077396-3b6e0a80-5a6b-11eb-8fa5-36bc4f4bad55.png)
![image](https://user-images.githubusercontent.com/62310132/105077404-3d37ce00-5a6b-11eb-90c1-63b6db96591d.png)

## Changelog
:cl:
**add:** Mascara de Payaso al loadout.
**add:** Traje de Payaso al loadout.
**add:** Zapatos de Payaso al loadout.
**add:** Mochila de Payaso al loadout.
**add:** Corneta de Payaso al loadout.
**add:** Boina de Mimo al loadout.
**add:** Mascara de Mimo al loadout.
**add:** Traje de mimo al loadout.
**add:** Tirantes de mimo al loadout.
**add:** Crayon de mimo al loadout.
/:cl: