### PR TITLE
Boombox y camara en el Loadout (Propuesta)

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -106,6 +106,16 @@ modular computers
 	display_name = "crayon de mimo"
 	path = /obj/item/weapon/pen/crayon/mime
 
+/datum/gear/utility/stream
+	display_name = "camara de directos"
+	path = /obj/item/device/camera/tvcamera
+	cost = 3
+
+/datum/gear/utility/boombox
+	display_name = "boombox"
+	path = /obj/item/device/boombox
+	cost = 3
+
 /****************
 Pouches and kits
 ****************/


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la cámara de prensa y la boombox al Loadout en la sección "Utility" por 3 puntos cada uno.

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/105430426-3b6c3700-5c32-11eb-8fcf-bbb7df58b2ed.png)

## Changelog
:cl:
**add:** Camara de prensa al Loadout.
**add:** Boombox al Loadout.
/:cl: