### PR TITLE
Opcion de alternar cabello en el casco

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -25,6 +25,17 @@
 	siemens_coefficient = 0.7
 	w_class = ITEM_SIZE_NORMAL
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_ADHERENT)
+	var/allow_hair_covering = 1
+
+//BoH
+/obj/item/clothing/head/helmet/verb/toggle_block_hair()
+	set name = "Toggle Helmet Hair Coverage"
+	set category = "Object"
+
+	if(allow_hair_covering)
+		flags_inv ^= BLOCKHEADHAIR
+		to_chat(usr, "<span class='notice'>[src] will now [flags_inv & BLOCKHEADHAIR ? "hide" : "show"] hair.</span>")
+	..()
 
 /obj/item/clothing/head/helmet/nt
 	name = "\improper corporate security helmet"


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la opcion de alternar que el casco cubra en cabello como estaba en BoH.

## Imágenes del cambio
![image](https://user-images.githubusercontent.com/62310132/106323980-1772ac00-6257-11eb-9d37-691fbfa9c382.png)

## Changelog
:cl:
**add:** Opcion de alternar cabello
/:cl: